### PR TITLE
FIX: number regexp should match '0%'

### DIFF
--- a/src/position.js
+++ b/src/position.js
@@ -155,7 +155,7 @@ define(function(require, exports) {
         // 将百分比转为像素值
         if (x.indexOf('%') !== -1) {
             //支持小数
-            x = x.replace(/(\d+\.?\d+)%/gi, function(m, d) {
+            x = x.replace(/(\d+(?:\.\d+)?)%/gi, function(m, d) {
                 return pinObject.size()[type] * (d / 100.0);
             });
         }


### PR DESCRIPTION
Hey guys, I found a bad case in arale/position, the number regexp didn't match percentage string '0%' , so I fix it, and here is the testcase: http://jsfiddle.net/45fpM/1/
