### PR TITLE
Do nothing when pinObject is a nonexistent element 

### DIFF
--- a/src/position.js
+++ b/src/position.js
@@ -21,9 +21,15 @@ define(function(require, exports) {
         pinObject = normalize(pinObject);
         baseObject = normalize(baseObject);
 
+        // if pinObject.element is not present
+        var element = pinObject.element;
+        if (element === VIEWPORT || element._id === 'VIEWPORT') {
+          return;
+        }
+
         // 设定目标元素的 position 为绝对定位
         // 若元素的初始 position 不为 absolute，会影响元素的 display、宽高等属性
-        var pinElement = $(pinObject.element);
+        var pinElement = $(element);
 
         if (pinElement.css('position') !== 'fixed' || isIE6) {
             pinElement.css('position', 'absolute');
@@ -207,7 +213,7 @@ define(function(require, exports) {
         } else {
             offset = getOffset(parent[0]);
         }
-            
+
         // 根据基准元素 offsetParent 的 border 宽度，来修正 offsetParent 的基准位置
         offset.top += numberize(parent.css('border-top-width'));
         offset.left += numberize(parent.css('border-left-width'));
@@ -231,7 +237,7 @@ define(function(require, exports) {
     //   -> http://jsfiddle.net/afc163/gMAcp/1/
     // 这里先实现一份
     // 参照 kissy 和 jquery 1.9.1
-    //   -> https://github.com/kissyteam/kissy/blob/master/src/dom/sub-modules/base/src/base/offset.js#L366 
+    //   -> https://github.com/kissyteam/kissy/blob/master/src/dom/sub-modules/base/src/base/offset.js#L366
     //   -> https://github.com/jquery/jquery/blob/1.9.1/src/offset.js#L28
     function getOffset(element) {
         var box = element.getBoundingClientRect(),

--- a/tests/position-spec.js
+++ b/tests/position-spec.js
@@ -314,6 +314,15 @@ define(function(require) {
             temp.remove();
         });
 
+        it('nonexistent element：Position.pin($("#nonexistent-element"), { element:"#base-element", x: "100px", y: "100px" })', function() {
+            Position.pin($('#nonexistent-element'), { element:'#base-element', x: "100px", y: "100px" });
+            // do nothing
+            expect(pinElement.offset().top).to.equal(0);
+            expect(pinElement.offset().left).to.equal(0);
+        });
+
+
+
     });
 });
 

--- a/tests/position-spec.js
+++ b/tests/position-spec.js
@@ -321,8 +321,6 @@ define(function(require) {
             expect(pinElement.offset().left).to.equal(0);
         });
 
-
-
     });
 });
 


### PR DESCRIPTION
Because `Position` normalizes pinObject (as in `Position.pin`'s signature), its `element` will become a `VIEWPORT` plain object when `pinObject` contains a nonexistent element. 
This would break the following [CSS query](https://github.com/aralejs/position/blob/master/src/position.js#L28) in old IE(<=9) if the user is not meticulous enough.

However, passing empty jQuery object is quite pervasive, and it is even harder to preclude pernicious problems like this: `$('<div id="must-exist">').appendTo('#yet-another-nonexistent')`. `jQuery` creates a detached `div` but removes it then because no container is found. The final result is still an empty $ object.

In old IE, querying css property of empty jQuery will produce an exception that freezes all subsequent code in the same context, even if `Position.pin` is wrapped in `try..catch..` block. In modern browsers this does not matter much but still halting futile code execution is preferred.

`Position` can be more care-free if the burden of validating element is placed not on users. I hope this patch can make it done.

I tried to write new test case in the specs but did not manage to set up the test environment. I only tested on my local project, I wish this revision will pass.

Best wishes
